### PR TITLE
bot: refresh blockhash more frequently when sending transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,22 +772,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.0",
+ "subtle",
 ]
 
 [[package]]
@@ -791,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.0",
+ "subtle",
 ]
 
 [[package]]
@@ -801,7 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.0",
+ "subtle",
 ]
 
 [[package]]
@@ -813,7 +809,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.4.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -826,7 +822,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.4.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -988,7 +984,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_bytes",
- "sha2 0.9.3",
+ "sha2",
  "zeroize",
 ]
 
@@ -1002,7 +998,7 @@ dependencies = [
  "ed25519-dalek",
  "failure",
  "hmac 0.9.0",
- "sha2 0.9.3",
+ "sha2",
 ]
 
 [[package]]
@@ -1148,6 +1144,12 @@ dependencies = [
  "redox_syscall 0.2.5",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -1487,6 +1489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,16 +1521,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
 ]
 
 [[package]]
@@ -1554,13 +1555,13 @@ dependencies = [
 
 [[package]]
 name = "hmac-drbg"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1586,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -1668,7 +1669,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.1",
  "http",
- "http-body 0.4.1",
+ "http-body 0.4.2",
  "httparse",
  "httpdate",
  "itoa",
@@ -1693,6 +1694,18 @@ dependencies = [
  "tokio 1.4.0",
  "tokio-rustls",
  "webpki",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.4",
+ "pin-project-lite 0.2.6",
+ "tokio 1.4.0",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1803,6 +1816,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -2043,18 +2065,50 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
- "crunchy",
- "digest 0.8.1",
+ "base64 0.12.3",
+ "digest 0.9.0",
  "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.0",
+ "serde",
+ "sha2",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -2267,6 +2321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,21 +2527,23 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.5.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc04551635026d3ac7bc646698ea1836a85ed2a26b7094fe1d15d8b14854c4a2"
+checksum = "84236d64f1718c387232287cf036eb6632a5ecff226f4ff9dccb8c2b79ba0bde"
 dependencies = [
+ "aliasable",
  "ouroboros_macro",
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.5.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec33dfceabec83cd0e95a5ce9d20e76ab3a5cbfef59659b8c927f69b93ed8ae"
+checksum = "f463857a6eb96c0136b1d56e56c718350cef30412ec065b48294799a088bca68"
 dependencies = [
  "Inflector",
+ "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.64",
@@ -2642,6 +2704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2779,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,22 +2834,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
  "prost-derive",
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.7.0"
+name = "prost-build"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes 1.0.1",
+ "heck",
+ "itertools 0.10.1",
+ "log 0.4.14",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.1",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.64",
@@ -2761,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
  "prost",
@@ -3107,7 +3221,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body 0.4.1",
+ "http-body 0.4.2",
  "hyper 0.14.4",
  "hyper-rustls",
  "hyper-tls",
@@ -3431,18 +3545,6 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
@@ -3553,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49379e5310962e5bd3372106733d94f5341b66dc3d64759310ab00f663a9da4a"
+checksum = "e644f9c77d5e59a35aa5fa8cb0a8f186332a3db19abb60f579cf3d750600cf1a"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3576,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b5a263c7f31f17e9b93e787ccfd75573e895fc5b5203994889407653683a37"
+checksum = "e7a79b6ef4ce2ff4e0a6c515a5030dfd75c69089ddf1a85f805b904516a8bf04"
 dependencies = [
  "bincode",
  "borsh",
@@ -3595,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d5abc7a18db6dad5a497f5421367336c296ad847ba4fdeb502697da569646"
+checksum = "70c75f0b27b97c7e27d7f6ba16e766990e9374d9a9ae0f60183619d5126b041e"
 dependencies = [
  "mio 0.7.11",
  "serde",
@@ -3607,9 +3709,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2de390f51bc42604effd8f1d1f18617c0a73c6870c7b814ec2fc23ee995aac"
+checksum = "810298b1760b59356dcccb354f913d059ce12ebf615dcf7bd4520fc991af5f38"
 dependencies = [
  "bincode",
  "futures 0.3.15",
@@ -3627,12 +3729,13 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f0684b415e02a6f8d681efe91f92acb4b484b8666e7bf242f63562436df733"
+checksum = "eb56a6bf09f3502afc77afaf6b1ed888e1a438ba5cd3f4f471dd82f27b7d80bb"
 dependencies = [
  "bincode",
  "byteorder",
+ "libsecp256k1",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -3647,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3533e04224962dc8956c5ea7087ebcfb9d26911f7c6a9b54d392bd21f0bdfef"
+checksum = "c57b6f6857ecf2c404cfb550419f67350b716eae49ede1f456d5b5de5b043540"
 dependencies = [
  "chrono",
  "clap",
@@ -3664,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2f42943ffbed139e426a2613b1e02de94f84185b968ea14244646c0e83b9a7"
+checksum = "e214778deefe3c170c1a33c5367d0594c0517bec4093098025cb7b2c662e9b8c"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3678,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35922e01f742bfcc7156a802aa9314c5510dfec28ea3794eadda1b732d8c71f"
+checksum = "932b71d73ef7a588700cbaa0244f25aa8bb3ef30fa2840bafa12aa4d0ca21708"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3712,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cc6edcb0c51cfdd2b0a0f3696002970c2715b422e3829b0e09b5236dc24352"
+checksum = "f6e67bbd8b59afa4c1d9adeae9bd4b332e34ee06a0e14bbc6222caeed6951f3c"
 dependencies = [
  "bincode",
  "chrono",
@@ -3727,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef17a44e186d99f520264bde47a4bfdac8914dc223ee0f9541ecfbded5a6cf7"
+checksum = "2dbcdbdb3a1e04530c4acfb04bc27acde6402a9dbf3c6d12bf5b072643dd03f7"
 dependencies = [
  "ahash 0.6.3",
  "base64 0.12.3",
@@ -3744,7 +3847,7 @@ dependencies = [
  "flate2",
  "fs_extra",
  "indexmap",
- "itertools",
+ "itertools 0.9.0",
  "libc",
  "log 0.4.14",
  "lru",
@@ -3793,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262e476c9578aa6fdea04a0e1084948da2e8a79fa4198230890f8c3296a56338"
+checksum = "668eb5b0fd053f35e5664ef6bf3f0da1e3b9bcb5643b8c4aa80cc4433b9d47ce"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -3818,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da253cdddd47aca0236f296e587da542305e362a8dc464db3ec583f140026118"
+checksum = "6fc784e9df8a8cea91e9ac5248287c162bbc50cecb8c8e9dc00048e8757ed1fb"
 dependencies = [
  "bzip2",
  "console 0.14.1",
@@ -3834,9 +3937,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d1d080f7ff9ce6f8f25fa95d855a103166ff4add01ba5568a4dfbbf18b3e07"
+checksum = "dca9b774547ae7eab0e20817c5179892ce9a9e9fa572d951aa31d01c5641bd71"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3885,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1e0d064e18bacd418a20b1d3c1a699bd6df1920fda7dbf1a0f84b764aaa0fb"
+checksum = "7f5ed8279eb2dca03341ff9ee7a5d9b84a9fc4a4a6d12f112e7ee9ec98ad6cab"
 dependencies = [
  "bs58 0.3.1",
  "bv",
@@ -3897,7 +4000,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "sha2 0.9.3",
+ "sha2",
  "solana-frozen-abi-macro",
  "solana-logger",
  "thiserror",
@@ -3905,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb85ca95ec91b6683e9a414cbdf74fc3d104eded6cb20439b2bb6eea22d3514"
+checksum = "888b45e492fdc5216b982437de9ef6bff96423fbe108c01710ecc8769c994a4e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -3917,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ded3d427db4a62c804ba9f6932f77cf43ea44fde938ad040d7a552e9f92a28"
+checksum = "9459d68ed69d636e7f5590308d2eab7db49eae13511ffb6d3e36508a833f10da"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
@@ -3928,16 +4031,16 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691bfcdc5c0ee81a1d923b363ef03eb8f477b807b6ef7671b73729facab68ab1"
+checksum = "b6109eb8b44d1f401909658f2acd192881c02158319cc638c1396178c1f7e0e2"
 dependencies = [
  "bincode",
  "bv",
  "clap",
  "flate2",
  "indexmap",
- "itertools",
+ "itertools 0.9.0",
  "log 0.4.14",
  "lru",
  "matches",
@@ -3970,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bb546400b0a87273815dcf82f7d2bc6d183da44acb61fc4698f2e118cfe2a3"
+checksum = "4cf8b63804d041e7f6ec935e0c1f597877a328be66452e6331c27c498f7f151e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3985,7 +4088,7 @@ dependencies = [
  "fs_extra",
  "futures 0.3.15",
  "futures-util",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "libc",
  "log 0.4.14",
@@ -3999,7 +4102,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_bytes",
- "sha2 0.9.3",
+ "sha2",
  "solana-bpf-loader-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -4024,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7afaad15211575f769c1f5389fca78a10fe9bc676c2fcc7b91b85be978eadca3"
+checksum = "5cd962c3fc95a433cd5e8368161fa54cfc9f216f66be06a71ccf05f8db3cc518"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4035,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973c24018c0ab2f5d59cf13a91e8877d4f6943adbaaae9fbde53a5ad1fd527b5"
+checksum = "1b0405692ecd5b0daea7a6ee8d076afa627492c25623a89e3519e6b8f773e790"
 dependencies = [
  "log 0.4.14",
  "solana-metrics",
@@ -4046,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c946b82f9870be526e08500f37b3959eae58f537bd3a03e11aa5aff0da3759bd"
+checksum = "b307addeeaf4516a3b96c41218725e76b4730f061aac06619b47ba2abcfc8078"
 dependencies = [
  "fast-math",
  "matches",
@@ -4057,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050216628bf064702a5efe721cfb65011dfb597fa70a7302879f142e5887764e"
+checksum = "52b191f80988c11b6be15c33e9fcd48086e0f8d7b64a5215a562b7fefd50858f"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -4071,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e91dc21b8cd419fa3ce94d4a9157445b3f7b9c238cc3cf93afaafed38f00ef8"
+checksum = "f826d57f78d3b40fe6c008813367ce70c44e1b2488270b6c68cc050a75d8bb6b"
 dependencies = [
  "bincode",
  "clap",
@@ -4093,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2316e590952066b36407388cdf30b508428f77e19f257b220582ba93c22ef9"
+checksum = "579e1a9bbfa132fff82f6d2f1546c97f95526bc235163d5482a0374f1bf54832"
 dependencies = [
  "log 0.4.14",
  "reqwest",
@@ -4104,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951356bc1a2e9e786ab90941324ad76da76c63cce4b7c1e5e5ef2dc6c0bdc383"
+checksum = "e1d86640fea2cca5160e6076644b5480afd7701b2fd9dca1efd30dcf9131f8f6"
 dependencies = [
  "bincode",
  "curve25519-dalek 2.1.2",
@@ -4125,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10fb08c25bd5a1818a1e75f95b568fff786ac270d9940aa918c2b259771f1db"
+checksum = "02fb465c918ba99a030902d78337440229ad9495960b2c0d1045b600ec3bce9c"
 dependencies = [
  "core_affinity",
  "crossbeam-channel 0.4.4",
@@ -4143,9 +4246,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d494621bfad15d6745a2bde5a5fa112c921011c00fa07987637d34bd544f191"
+checksum = "0dd1398350ee06070854399743f4d726b1ea7f71766714b0767cc6133ba18c7b"
 dependencies = [
  "bincode",
  "blake3",
@@ -4155,8 +4258,9 @@ dependencies = [
  "bv",
  "curve25519-dalek 2.1.2",
  "hex",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
+ "libsecp256k1",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -4166,7 +4270,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2 0.9.3",
+ "sha2",
  "sha3",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -4177,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4210bd144560d7ffaeb871fea50c04b7c3d9dab86fb0656ed08ce373c2e6e92e"
+checksum = "5f1b0f6563b79f3cbbca0f0a5ce04eca634d82c14fa922d0ed662c1609484161"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -4203,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe14a0b8d7c2181cc6692855cfe40c90e87c76728ccc17110ec6d2244817e74f"
+checksum = "436c020428e66f511568edbb1e3d2bddee3336c2dadea4d45ecdcd57572c55bf"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4213,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b109992a9f9e972a09951fe0f9bc42daa17877a937e3195f945cf7bff6a84b68"
+checksum = "e8865f453aabda56c7200b54ef463b1dd1aa824e326293ab5d8ce6a858d5e5bd"
 dependencies = [
  "base32",
  "console 0.14.1",
@@ -4234,15 +4338,15 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84896064aa19d8d715f3a143291bf2bec9dad2fca0a7803b131ed3c606afe8"
+checksum = "da0625810a6644d1dd755b88501d2677aadcbdca4c4737bc1dab5a58dfe64ed7"
 dependencies = [
  "base64 0.12.3",
  "bincode",
  "bs58 0.3.1",
  "crossbeam-channel 0.4.4",
- "itertools",
+ "itertools 0.9.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -4267,6 +4371,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-storage-bigtable",
+ "solana-streamer",
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
@@ -4278,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60faef270e12f4eadaf5bfbc71af60cf8ecf84b7afaf72476c4e375de9c47c8c"
+checksum = "932185b5b954d3828a39df54487391cd5b982aa994c39c261771b8f8599210bb"
 dependencies = [
  "arrayref",
  "bincode",
@@ -4293,7 +4398,7 @@ dependencies = [
  "dir-diff",
  "flate2",
  "fnv",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "libc",
  "libloading 0.6.7",
@@ -4329,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045476e010fc091d01ec7ba6854328894db20e37b70124f05bf851cdeb60113b"
+checksum = "5475909aab00963154a2748cb3ac78eacce511c2a194b28e041c926099c0d286"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -4346,7 +4451,7 @@ dependencies = [
  "generic-array 0.14.4",
  "hex",
  "hmac 0.10.1",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "libsecp256k1",
  "log 0.4.14",
@@ -4364,7 +4469,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.9.3",
+ "sha2",
  "sha3",
  "solana-crate-features",
  "solana-frozen-abi",
@@ -4378,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7afe714e9abb9a93215bf5710ee1e244046f2189574301b3e38afb4a14c8f6"
+checksum = "3839bc6b8f3163878e7f1675a0faffa641edf760aec1d9a7a056f71712e94642"
 dependencies = [
  "bs58 0.3.1",
  "proc-macro2 1.0.24",
@@ -4391,16 +4496,10 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f67361482a020437060ef48c5d738f69179958304d079638c9cd23ed239c83"
+checksum = "8dd7e16a637da71fbb12343ea57e107c49b91ee3d3f858ff09eb65b712bfb76a"
 dependencies = [
- "bincode",
- "digest 0.9.0",
- "libsecp256k1",
- "rand 0.7.3",
- "sha3",
- "solana-logger",
  "solana-sdk",
 ]
 
@@ -4429,6 +4528,7 @@ dependencies = [
  "solana-logger",
  "solana-notifier",
  "solana-sdk",
+ "solana-streamer",
  "solana-transaction-status",
  "solana-validator",
  "solana-vote-program",
@@ -4439,9 +4539,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954770d1ddf8618b96e2150a2da349a969df47046d4f7e11aca94b3b34267cf2"
+checksum = "626a1205b053064cf2824ae09c5660e6b93443591f65ff5976c9dac1bfc1675b"
 dependencies = [
  "bincode",
  "log 0.4.14",
@@ -4461,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b8b7766778c7b95348264c66e25b02bf796fad129807a2d28d77c6684a6401"
+checksum = "9ea5077861cf1ac5f59133452d2311a299e4ac4164126c7b56db7c306dc5eb85"
 dependencies = [
  "arc-swap 0.4.8",
  "backoff",
@@ -4490,9 +4590,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777a69aecf38cefc8ee1fcff22aca7495fd76322c67a8f493078086e214ec32a"
+checksum = "4ecbf4a9ced676ec9c9e9d196675454eb40f9b5f38aec42407d838de8effcf7b"
 dependencies = [
  "bincode",
  "bs58 0.3.1",
@@ -4502,13 +4602,14 @@ dependencies = [
  "solana-account-decoder",
  "solana-sdk",
  "solana-transaction-status",
+ "tonic-build",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6aae28c2155da08cab6312cb8875d6335b75d69a4478f18ae778fa05d9193d9"
+checksum = "fb9a6e319595af0fac40223937567eef6464c23d9afacba8bb20c26830687e8e"
 dependencies = [
  "libc",
  "log 0.4.14",
@@ -4523,9 +4624,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30dab3ea323dbdc068cfc3065b9595a54d61f6dcb3943ca5ed8014f11e39a7cf"
+checksum = "ad1b1862d077e139a0da1649ed70128df11daa1e1f1dffcef539ed6429a278f1"
 dependencies = [
  "clap",
  "libc",
@@ -4541,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fc7eb73bd4b76a8148c022914ab8bec49395be91dd493d296e818d21f8b37"
+checksum = "8ef363db47e30b1b0f9a1a8a3d2fec529ff51588b66b385e1f1ee7db9acd48dc"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -4565,9 +4666,9 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead700c334fac9670db098f7434c820430f85e2aad9a37659303875800566950"
+checksum = "7ab577039ef1ee3bfbcf38a165f2636f4fd967650a087d477a85733e0e1c0364"
 dependencies = [
  "base64 0.12.3",
  "bincode",
@@ -4605,6 +4706,7 @@ dependencies = [
  "solana-rpc",
  "solana-runtime",
  "solana-sdk",
+ "solana-streamer",
  "solana-version",
  "solana-vote-program",
  "symlink",
@@ -4612,9 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36ce09f7a1c47585378fa5a03a5d95dffb23b3b613ad3904385ec97fee91cf"
+checksum = "d72405fc6f59f499fbea7f79e6fdd1ed20a76c953670dd7416e3fe4f1c2992cc"
 dependencies = [
  "log 0.4.14",
  "rustc_version",
@@ -4628,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.7.4"
+version = "1.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c78004e2a5fdf26ca9561a955a1f447440570ae65decb30650340e22e6ce1"
+checksum = "4c338f2c1bb6056380947a5dcfa0b132a2021a1177f944a8d805cccd14a26d29"
 dependencies = [
  "bincode",
  "log 0.4.14",
@@ -4674,9 +4776,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adc47eebe5d2b662cbaaba1843719c28a67e5ec5d0460bc3ca60900a51f74e2"
+checksum = "393e2240d521c3dd770806bff25c2c00d761ac962be106e14e22dd912007f428"
 dependencies = [
  "solana-program",
  "spl-token",
@@ -4712,9 +4814,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfa8fd791aeb4d7ad5fedb7872478de9f4e8b4fcb02dfd9e7f2f9ae3f3ddd73"
+checksum = "93bfdd5bd7c869cb565c7d7635c4fafe189b988a0bdef81063cd9585c6b8dc01"
 dependencies = [
  "arrayref",
  "num-derive",
@@ -4799,12 +4901,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -5039,7 +5135,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.3",
+ "sha2",
  "thiserror",
  "unicode-normalization",
  "zeroize",
@@ -5179,6 +5275,16 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "log 0.4.14",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite 0.2.6",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -5406,9 +5512,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91491e5f15431f2189ec8c1f9dcbadac949450399c22c912ceae9570eb472f61"
+checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5418,8 +5524,9 @@ dependencies = [
  "futures-util",
  "h2 0.3.1",
  "http",
- "http-body 0.4.1",
+ "http-body 0.4.2",
  "hyper 0.14.4",
+ "hyper-timeout",
  "percent-encoding 2.1.0",
  "pin-project",
  "prost",
@@ -5429,16 +5536,29 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.6.5",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.6"
+name = "tonic-build"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "d12faebbe071b06f486be82cc9318350814fdd07fcb28f3690840cd770599283"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "prost-build",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -5603,6 +5723,12 @@ checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -5897,6 +6023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+dependencies = [
+ "either",
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6024,6 +6160,6 @@ checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
 dependencies = [
  "cc",
  "glob",
- "itertools",
+ "itertools 0.9.0",
  "libc",
 ]

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -22,25 +22,26 @@ semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.62"
 serde_yaml = "0.8.13"
-solana-account-decoder = "1.7.4"
-solana-clap-utils = "1.7.4"
-solana-cli-config = "1.7.4"
-solana-client = "1.7.4"
+solana-account-decoder = "1.7.10"
+solana-clap-utils = "1.7.10"
+solana-cli-config = "1.7.10"
+solana-client = "1.7.10"
 solana-foundation-delegation-program-cli = { path = "../cli" }
 solana-foundation-delegation-program-registry = { path = "../program" }
-solana-logger = "1.7.4"
-solana-notifier = "1.7.4"
-solana-sdk = "1.7.4"
-solana-transaction-status = "1.7.4"
-solana-vote-program = "1.7.4"
+solana-logger = "1.7.10"
+solana-notifier = "1.7.10"
+solana-sdk = "1.7.10"
+solana-streamer = "1.7.10"
+solana-transaction-status = "1.7.10"
+solana-vote-program = "1.7.10"
 spl-stake-pool = "0.4"
 spl-token = "3.1"
 thiserror = "1.0.25"
 
 [dev-dependencies]
 indicatif = "0.15.0"
-solana-validator = "1.7.4"
-solana-vote-program = "1.7.4"
+solana-validator = "1.7.10"
+solana-vote-program = "1.7.10"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -1051,6 +1051,7 @@ mod test {
             native_token::sol_to_lamports,
             signature::{Keypair, Signer},
         },
+        solana_streamer::socket::SocketAddrSpace,
         solana_validator::test_validator::*,
         spl_stake_pool::find_withdraw_authority_program_address,
     };
@@ -1142,7 +1143,7 @@ mod test {
                 /* enable_warmup_epochs = */ false,
             ))
             .add_program("spl_stake_pool", spl_stake_pool::id());
-        let (test_validator, authorized_staker) = test_validator_genesis.start();
+        let (test_validator, authorized_staker) = test_validator_genesis.start(SocketAddrSpace::Unspecified);
 
         let (rpc_client, _recent_blockhash, _fee_calculator) = test_validator.rpc_client();
 

--- a/bot/src/stake_pool_v0.rs
+++ b/bot/src/stake_pool_v0.rs
@@ -827,6 +827,7 @@ mod test {
             native_token::sol_to_lamports,
             signature::{Keypair, Signer},
         },
+        solana_streamer::socket::SocketAddrSpace,
         solana_validator::test_validator::*,
     };
 
@@ -909,7 +910,7 @@ mod test {
             MINIMUM_SLOTS_PER_EPOCH,
             /* enable_warmup_epochs = */ false,
         ));
-        let (test_validator, authorized_staker) = test_validator_genesis.start();
+        let (test_validator, authorized_staker) = test_validator_genesis.start(SocketAddrSpace::Unspecified);
 
         let (rpc_client, _recent_blockhash, _fee_calculator) = test_validator.rpc_client();
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,12 +14,12 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2.33.3"
-solana-account-decoder = "=1.7.4"
-solana-clap-utils = "=1.7.4"
-solana-cli-config = "=1.7.4"
-solana-client = "=1.7.4"
+solana-account-decoder = "=1.7.10"
+solana-clap-utils = "=1.7.10"
+solana-cli-config = "=1.7.10"
+solana-client = "=1.7.10"
 solana-foundation-delegation-program-registry = { version = "1.0.1", path = "../program" }
-solana-logger = "=1.7.4"
-solana-remote-wallet = "=1.7.4"
-solana-sdk = "=1.7.4"
+solana-logger = "=1.7.10"
+solana-remote-wallet = "=1.7.10"
+solana-sdk = "=1.7.10"
 tokio = { version = "1", features = ["full"] }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -10,15 +10,15 @@ repository = "https://github.com/solana-labs/stake-o-matic"
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9"
-solana-program = "1.7.4"
+solana-program = "1.7.10"
 
 [features]
 test-bpf = []
 
 [dev-dependencies]
 assert_matches = "1.4.0"
-solana-program-test = "1.7.4"
-solana-sdk = "1.7.4"
+solana-program-test = "1.7.10"
+solana-sdk = "1.7.10"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -4,7 +4,10 @@
 #
 set -ex
 
-"$(dirname "$0")"/fetch-release.sh "$STAKE_O_MATIC_RELEASE"
+#"$(dirname "$0")"/fetch-release.sh "$STAKE_O_MATIC_RELEASE"
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+solana_stake_o_matic="cargo run --bin solana-stake-o-matic --"
 
 if [[ -n $FOLLOWER ]]; then
   REQUIRE_CLASSIFICATION="--require-classification"
@@ -68,13 +71,13 @@ STAKE_POOL_ARGS=(
 )
 
 if [[ $CLUSTER = "testnet-stake-pool" ]]; then
-  ./solana-stake-o-matic "${TESTNET_ARGS[@]}" "${STAKE_POOL_ARGS[@]}"
+  $solana_stake_o_matic "${TESTNET_ARGS[@]}" "${STAKE_POOL_ARGS[@]}"
 elif [[ $CLUSTER = "mainnet-beta-stake-pool" ]]; then
-  ./solana-stake-o-matic "${MAINNET_BETA_ARGS[@]}" "${STAKE_POOL_ARGS[@]}"
+  $solana_stake_o_matic "${MAINNET_BETA_ARGS[@]}" "${STAKE_POOL_ARGS[@]}"
 elif [[ $CLUSTER == "testnet" ]]; then
-  ./solana-stake-o-matic "${TESTNET_ARGS[@]}" "${NOT_A_STAKE_POOL_ARGS[@]}"
+  $solana_stake_o_matic "${TESTNET_ARGS[@]}" "${NOT_A_STAKE_POOL_ARGS[@]}"
 elif [[ $CLUSTER == "mainnet-beta" ]]; then
-  ./solana-stake-o-matic "${MAINNET_BETA_ARGS[@]}" "${NOT_A_STAKE_POOL_ARGS[@]}"
+  $solana_stake_o_matic "${MAINNET_BETA_ARGS[@]}" "${NOT_A_STAKE_POOL_ARGS[@]}"
 else
   echo "CLUSTER must be set to testnet-stake-pool, mainnet-beta-stake-pool, testnet, or mainnet-beta"
   exit 1


### PR DESCRIPTION
#### Problem

The bot attempts to use the same recent blockhash for all transactions when sending transactions.  If there are many transactions to send, the recent blockhash can expire before all transactions have been sent, leading to many failures

#### Changes

Occasionally query the cluster to check the current blockhash's TTL and refresh it when half-expired