### PR TITLE
Add an option to print list output in json format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -4099,6 +4099,7 @@ name = "solana-foundation-delegation-program-cli"
 version = "1.0.6"
 dependencies = [
  "clap",
+ "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-cli-config",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2.33.3"
+serde_json = "1.0.83"
 solana-account-decoder = "=1.7.11"
 solana-clap-utils = "=1.7.11"
 solana-cli-config = "=1.7.11"


### PR DESCRIPTION
The "list" command currently just prints the participants to stdout in no specific format (just regular formatting).

This PR adds an optional flag to allow printing all the participants in a json array. With this change, it will be much easier to parse the output. For example, suppose the output saved in a file:
```
solana-foundation-delegation-program list --state approved --output-format json > approved.json
```
Picking Python, one can then parse and operate on the elements with just a couple lines instead of regex matching
```python
import json

with open('/Users/stevecz/code/participants.json', 'r') as json_file:
	data = json.load(json_file)
	# Printing the types to illustrate how to access
	print(type(data))
	print(type(data[0]))
	for i in range(0, 5):
		print(data[i])
```
And running yields:
```
<class 'list'>
<class 'dict'>
{'mainnet_identity': 'BXLTXNYwCnAWQtZ9uErdNVr2vfPWtn5QFSjcpNNr8Tmj', 'state': 'Pending', 'testnet_identity': '5R2gQZ5RL2jrBkbNLaz4iAGxt6AcBtLhij6VyZii3jep'}
{'mainnet_identity': '5X39mKkK1QJBnFmzryeRbVmSKQDHR8bvUMm22gQS95YL', 'state': 'Pending', 'testnet_identity': 'BZdJbAKwNJgKXSfP6gee8DPe7ipJdwT9kmA5ZvqUZTs5'}
{'mainnet_identity': 'Y3JWEkrfgMVJeVqomjDdqLNcowzU2TtAdi6TLgArLsN', 'state': 'Approved', 'testnet_identity': 'Akk9n4Ed2GwY4LWSgXqigQqz9bFVUE4Uqy8iKKQY4Uyk'}
{'mainnet_identity': 'BDcLiEjyENE3ooyHgsGcwHVkQPLTCDT29hPx6dyMAwx2', 'state': 'Rejected', 'testnet_identity': 'AP8Rrab6whViUb92R3fXimCfmyiJA9vFrFjKHtvYpi48'}
{'mainnet_identity': '3vYPCtncFxQ1RVtSpB2HRg1udHfeVPWPpWALuJaMcLx3', 'state': 'Approved', 'testnet_identity': 'DVnKs7XAL9au7cWrTT335gZ3agJVwrqeSVnSWANo1SJG'}
```
