### PR TITLE
Change up retry params to match a 32-slot epoch

### DIFF
--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -45,8 +45,8 @@ fn new_tpu_client_with_retry(
         client_error::{ClientError, ClientErrorKind},
         rpc_request::RpcError,
     };
-    let mut retries = 50; // reconnecting with a 32-slot epoch can sometimes take awhile
-    let sleep_ms = 400;
+    let mut retries = 64; // connecting with a 32-slot epoch can sometimes take awhile
+    let sleep_ms = 200;
     while retries > 0 {
         match TpuClient::new(
             rpc_client.clone(),


### PR DESCRIPTION
The test errors are both regarding trying to create accounts that already exist, so maybe a slow connection to the test validator is causing issues. Let's try to more aggressively create the TPU client and see if that resolves it