### PR TITLE
Bot: Add performance_waiver_release_version argument

### DIFF
--- a/bot/src/db.rs
+++ b/bot/src/db.rs
@@ -129,6 +129,7 @@ pub struct EpochConfig {
     pub min_testnet_participation: Option<(/*n:*/ usize, /*m:*/ usize)>,
     pub baseline_stake_amount_lamports: Option<u64>,
     pub require_performance_metrics_reporting: Option<bool>,
+    pub performance_waiver_release_version: Option<semver::Version>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -83,7 +83,7 @@ MAINNET_BETA_ARGS=(
   --min-self-stake-exceptions-key ${SELF_STAKE_EXCEPTIONS_KEY:?}
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
-  --performance-waiver-release-version 1.14.0
+  --performance-waiver-release-version 1.14.14
 #  --require-performance-metrics-reporting
 )
 

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -83,6 +83,7 @@ MAINNET_BETA_ARGS=(
   --min-self-stake-exceptions-key ${SELF_STAKE_EXCEPTIONS_KEY:?}
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
+  --performance-waiver-release-version 1.14.0
 #  --require-performance-metrics-reporting
 )
 


### PR DESCRIPTION
Validators with the release version or higher do not have to meet performance requirements