### PR TITLE
bot: Combine TPU and RPC clients to avoid creating TPU client

### DIFF
--- a/bot/src/generic_stake_pool.rs
+++ b/bot/src/generic_stake_pool.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{rpc_client_utils::MultiClient, Config},
+    crate::rpc_client_utils::MultiClient,
     serde::{Deserialize, Serialize},
     solana_sdk::pubkey::Pubkey,
     std::{
@@ -38,7 +38,6 @@ pub trait GenericStakePool {
     fn apply(
         &mut self,
         client: &MultiClient,
-        config: &Config,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<

--- a/bot/src/generic_stake_pool.rs
+++ b/bot/src/generic_stake_pool.rs
@@ -1,12 +1,10 @@
 use {
-    crate::Config,
+    crate::{rpc_client_utils::MultiClient, Config},
     serde::{Deserialize, Serialize},
-    solana_client::rpc_client::RpcClient,
     solana_sdk::pubkey::Pubkey,
     std::{
         collections::{HashMap, HashSet},
         error,
-        sync::Arc,
     },
 };
 
@@ -39,7 +37,7 @@ pub trait GenericStakePool {
     /// Fourth value in returned tuple is the calculated bonus stake amount
     fn apply(
         &mut self,
-        rpc_client: Arc<RpcClient>,
+        client: &MultiClient,
         config: &Config,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -994,7 +994,8 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
         _ => unreachable!(),
     };
 
-    Ok((config, MultiClient::new(rpc_client, tpu_client), stake_pool))
+    let client = MultiClient::new(rpc_client, tpu_client, &config);
+    Ok((config, client, stake_pool))
 }
 
 type ClassifyResult = (
@@ -2427,7 +2428,6 @@ fn main() -> BoxResult<()> {
         let (stake_pool_notes, validator_stake_actions, unfunded_validators, bonus_stake_amount) =
             stake_pool.apply(
                 &client,
-                &config,
                 pre_run_dry_run || config.dry_run,
                 &desired_validator_stake,
             )?;

--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -1,6 +1,6 @@
 use solana_sdk::pubkey::Pubkey;
 use {
-    crate::{generic_stake_pool::*, rpc_client_utils::MultiClient, Config},
+    crate::{generic_stake_pool::*, rpc_client_utils::MultiClient},
     std::{
         collections::{HashMap, HashSet},
         error,
@@ -17,7 +17,6 @@ impl GenericStakePool for NoopStakePool {
     fn apply(
         &mut self,
         _client: &MultiClient,
-        _config: &Config,
         _dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<

--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -1,11 +1,9 @@
 use solana_sdk::pubkey::Pubkey;
 use {
-    crate::{generic_stake_pool::*, Config},
-    solana_client::rpc_client::RpcClient,
+    crate::{generic_stake_pool::*, rpc_client_utils::MultiClient, Config},
     std::{
         collections::{HashMap, HashSet},
         error,
-        sync::Arc,
     },
 };
 
@@ -18,7 +16,7 @@ pub fn new() -> NoopStakePool {
 impl GenericStakePool for NoopStakePool {
     fn apply(
         &mut self,
-        _rpc_client: Arc<RpcClient>,
+        _client: &MultiClient,
         _config: &Config,
         _dry_run: bool,
         desired_validator_stake: &[ValidatorStake],


### PR DESCRIPTION
#### Problem

The upgrade to 1.13 is failing tests often because of reconnecting so often to a cluster with short epochs. That upgrade is very important because it uses QUIC, so it needs to be unblocked soon, especially before the cluster moves to blocking UDP totally.

#### Solution

Bundle the RPC and TPU clients into `Clients`, and only create the TPU client once.

Note: I also have a commit that can be added to https://github.com/solana-foundation/stake-o-matic/pull/451, but it seemed neater to *not* pile onto that PR, and instead make this change separately

Also note: I tested this by running stake-o-matic.sh with a noop stake pool on testnet