### PR TITLE
add ability to optionally submit transactions via rpc

### DIFF
--- a/bot/src/generic_stake_pool.rs
+++ b/bot/src/generic_stake_pool.rs
@@ -1,4 +1,5 @@
 use {
+    crate::Config,
     serde::{Deserialize, Serialize},
     solana_client::rpc_client::RpcClient,
     solana_sdk::pubkey::Pubkey,
@@ -39,7 +40,7 @@ pub trait GenericStakePool {
     fn apply(
         &mut self,
         rpc_client: Arc<RpcClient>,
-        websocket_url: &str,
+        config: &Config,
         dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -262,6 +262,7 @@ pub struct Config {
     blocklist_datacenter_asns: Option<Vec<u64>>,
     require_dry_run_to_distribute_stake: bool,
     performance_waiver_release_version: Option<semver::Version>,
+    use_rpc_tx_submission: bool,
 }
 
 const DEFAULT_MAINNET_BETA_JSON_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
@@ -308,6 +309,7 @@ impl Config {
             blocklist_datacenter_asns: None,
             require_dry_run_to_distribute_stake: false,
             performance_waiver_release_version: None,
+            use_rpc_tx_submission: false,
         }
     }
 
@@ -645,6 +647,12 @@ fn get_config() -> BoxResult<(Config, Arc<RpcClient>, Box<dyn GenericStakePool>)
                 .takes_value(false)
                 .help("If set, only distribute stake if there is a dry run summary in the wiki repo")
         )
+        .arg(
+            Arg::with_name("use_rpc_tx_submission")
+                .long("use-rpc-tx-submission")
+                .takes_value(false)
+                .help("Submit transactions via RPC client instead of TPU client")
+        )
         .subcommand(
             SubCommand::with_name("stake-pool-v0").about("Use the stake-pool v0 solution")
                 .arg(
@@ -891,6 +899,7 @@ fn get_config() -> BoxResult<(Config, Arc<RpcClient>, Box<dyn GenericStakePool>)
         .value_of("participant_json_rpc_url")
         .unwrap()
         .to_string();
+    let use_rpc_tx_submission = matches.is_present("use_rpc_tx_submission");
 
     let mut config = Config {
         json_rpc_url,
@@ -927,6 +936,7 @@ fn get_config() -> BoxResult<(Config, Arc<RpcClient>, Box<dyn GenericStakePool>)
         blocklist_datacenter_asns,
         require_dry_run_to_distribute_stake,
         performance_waiver_release_version,
+        use_rpc_tx_submission,
     };
 
     let stake_pool: Box<dyn GenericStakePool> = match matches.subcommand() {

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -2413,7 +2413,7 @@ fn main() -> BoxResult<()> {
         let (stake_pool_notes, validator_stake_actions, unfunded_validators, bonus_stake_amount) =
             stake_pool.apply(
                 rpc_client,
-                &config.websocket_url,
+                &config,
                 pre_run_dry_run || config.dry_run,
                 &desired_validator_stake,
             )?;

--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -1,6 +1,6 @@
 use solana_sdk::pubkey::Pubkey;
 use {
-    crate::generic_stake_pool::*,
+    crate::{generic_stake_pool::*, Config},
     solana_client::rpc_client::RpcClient,
     std::{
         collections::{HashMap, HashSet},
@@ -19,7 +19,7 @@ impl GenericStakePool for NoopStakePool {
     fn apply(
         &mut self,
         _rpc_client: Arc<RpcClient>,
-        _websocket_url: &str,
+        _config: &Config,
         _dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<

--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use {
+    crate::Config,
     indicatif::{ProgressBar, ProgressStyle},
     log::*,
     solana_client::{
@@ -70,7 +71,7 @@ fn new_tpu_client_with_retry(
 
 pub fn send_and_confirm_transactions_with_spinner(
     rpc_client: Arc<RpcClient>,
-    websocket_url: &str,
+    config: &Config,
     dry_run: bool,
     transactions: Vec<Transaction>,
     signer: &Keypair,
@@ -84,7 +85,7 @@ pub fn send_and_confirm_transactions_with_spinner(
     let transaction_resend_interval = Duration::from_secs(4); /* Retry batch send after 4 seconds */
 
     progress_bar.set_message("Connecting...");
-    let tpu_client = new_tpu_client_with_retry(&rpc_client, websocket_url)?;
+    let tpu_client = new_tpu_client_with_retry(&rpc_client, &config.websocket_url)?;
 
     let mut transactions = transactions.into_iter().enumerate().collect::<Vec<_>>();
     let num_transactions = transactions.len() as f64;

--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -133,7 +133,9 @@ pub fn send_and_confirm_transactions_with_spinner(
                 for (index, (_i, transaction)) in pending_transactions.values().enumerate() {
                     let method = if dry_run {
                         "DRY RUN"
-                    } else if tpu_client.send_transaction(transaction) {
+                    } else if !config.use_rpc_tx_submission
+                        && tpu_client.send_transaction(transaction)
+                    {
                         "TPU"
                     } else {
                         let _ = rpc_client.send_transaction_with_config(

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -45,6 +45,11 @@ if [[ -n $REQUIRE_DRY_RUN_TO_DISTRIBUTE_STAKE ]]; then
   REQUIRE_DRY_RUN_TO_DISTRIBUTE_STAKE="--require-dry-run-to-distribute-stake"
 fi
 
+: "${USE_RPC_TX_SUBMISSION:=false}"
+if $USE_RPC_TX_SUBMISSION; then
+  MAYBE_USE_RPC_TX_SUBMISSION="--use-rpc-tx-submission"
+fi
+
 # shellcheck disable=SC2206
 TESTNET_ARGS=(
   --url ${URL[@]:?}
@@ -59,6 +64,7 @@ TESTNET_ARGS=(
   --max-old-release-version-percentage 20
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
+  $MAYBE_USE_RPC_TX_SUBMISSION
 #  --require-performance-metrics-reporting
 )
 
@@ -84,6 +90,7 @@ MAINNET_BETA_ARGS=(
   --performance-db-url ${PERFORMANCE_DB_URL:?}
   --performance-db-token ${PERFORMANCE_DB_TOKEN:?}
   --performance-waiver-release-version 1.14.14
+  $MAYBE_USE_RPC_TX_SUBMISSION
 #  --require-performance-metrics-reporting
 )
 


### PR DESCRIPTION
stake-o-matic currently targets v1.7 solana crates. the tpu client in these crates is still the old udp one, which very few validators still have enabled and exposed to the world. this makes transaction submission very slow as transactions can only land when one of these validators is leader.

even after crates are upgraded to a newer version that supports quic tpu, not being a staked validator _may_ make tpu transaction submission unreliable as quic seats for unstaked tpu peers are limited.

since our rpc provider proxies transaction submission through staked nodes, add the ability to optionally submit transactions through them, via rpc


NOTE: #457 should land first and this branch rebased before merging