### PR TITLE
bot: Retry `get_program_accounts` if it times out

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -36,7 +36,7 @@ use {
         native_token::*,
         pubkey::Pubkey,
         slot_history::{self, SlotHistory},
-        stake::{self, state::StakeState},
+        stake::state::StakeState,
         stake_history::StakeHistory,
         sysvar,
     },
@@ -1213,7 +1213,7 @@ fn get_self_stake_by_vote_account(
     }
 
     info!("Fetching stake accounts...");
-    let all_stake_accounts = rpc_client.get_program_accounts(&stake::program::id())?;
+    let all_stake_accounts = get_all_stake_with_retry(rpc_client, None)?;
 
     let stake_history_account = rpc_client
         .get_account_with_commitment(&sysvar::stake_history::id(), CommitmentConfig::finalized())?

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         generic_stake_pool::*,
         rpc_client_utils::{
-            get_all_stake, send_and_confirm_transactions_with_spinner, MultiClient,
+            get_all_stake_by_staker, send_and_confirm_transactions_with_spinner, MultiClient,
         },
     },
     log::*,
@@ -421,7 +421,7 @@ fn withdraw_inactive_stakes_to_staker(
 ) -> Result<(), Box<dyn error::Error>> {
     let mut transactions = vec![];
     let (all_stake_addresses, _all_stake_total_amount) =
-        get_all_stake(client, authorized_staker.pubkey())?;
+        get_all_stake_by_staker(client, authorized_staker.pubkey())?;
 
     for stake_address in all_stake_addresses {
         let stake_account = client
@@ -882,7 +882,10 @@ mod test {
     };
 
     fn num_stake_accounts(rpc_client: &RpcClient, authority: Pubkey) -> usize {
-        get_all_stake(rpc_client, authority).unwrap().0.len()
+        get_all_stake_by_staker(rpc_client, authority)
+            .unwrap()
+            .0
+            .len()
     }
 
     fn validator_stake_balance(
@@ -1055,7 +1058,7 @@ mod test {
             );
             {
                 let (all_stake, all_stake_total_amount) =
-                    get_all_stake(&client, withdraw_authority).unwrap();
+                    get_all_stake_by_staker(&client, withdraw_authority).unwrap();
                 assert_eq!(all_stake_total_amount, current_reserve_amount);
                 assert_eq!(all_stake.len(), 1);
                 assert!(all_stake.contains(&pool_reserve_stake));

--- a/bot/src/stake_pool_v0.rs
+++ b/bot/src/stake_pool_v0.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         generic_stake_pool::*,
         rpc_client_utils::{
-            get_all_stake, send_and_confirm_transactions_with_spinner, MultiClient,
+            get_all_stake_by_staker, send_and_confirm_transactions_with_spinner, MultiClient,
         },
     },
     log::*,
@@ -145,7 +145,7 @@ impl GenericStakePool for StakePool {
         }
 
         let (all_stake_addresses, all_stake_total_amount) =
-            get_all_stake(client, self.authorized_staker.pubkey())?;
+            get_all_stake_by_staker(client, self.authorized_staker.pubkey())?;
 
         info!("Merge orphaned stake into the reserve");
         let deactivated_merged_stake = merge_orphaned_stake_accounts(
@@ -843,7 +843,7 @@ mod test {
     };
 
     fn num_stake_accounts(rpc_client: &RpcClient, authorized_staker: &Keypair) -> usize {
-        get_all_stake(rpc_client, authorized_staker.pubkey())
+        get_all_stake_by_staker(rpc_client, authorized_staker.pubkey())
             .unwrap()
             .0
             .len()
@@ -908,7 +908,6 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Fails on occasion due to timing issues with short epochs in test framework"]
     fn this_test_is_too_big_and_slow() {
         solana_logger::setup_with_default("solana_stake_o_matic=info");
 
@@ -978,7 +977,7 @@ mod test {
                 );
 
                 let (all_stake, all_stake_total_amount) =
-                    get_all_stake(&client, authorized_staker_address).unwrap();
+                    get_all_stake_by_staker(&client, authorized_staker_address).unwrap();
                 assert_eq!(all_stake_total_amount, total_stake_amount_plus_min);
                 assert_eq!(all_stake.len(), 1);
                 assert!(all_stake.contains(&reserve_stake_address));


### PR DESCRIPTION
#### Problem

The bot dies if it reaches a timeout on `get_program_accounts` when fetching all stake accounts. This is an extremely heavy operation, so it makes sense that it times out once in awhile.

#### Solution

As a first step, just wait and retry if there's a timeout.

This re-enables the stake_pool_v0 test, which was succeeding in #465, but was ignored.