### PR TITLE
program: Update to Solana 1.13

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -10,15 +10,15 @@ repository = "https://github.com/solana-foundation/stake-o-matic"
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9"
-solana-program = "1.7.11"
+solana-program = "1.13.6"
 
 [features]
 test-bpf = []
 
 [dev-dependencies]
 assert_matches = "1.4.0"
-solana-program-test = "1.7.11"
-solana-sdk = "1.7.11"
+solana-program-test = "1.13.6"
+solana-sdk = "1.13.6"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
#### Problem

There was an issue during the upgrade to 1.13 with the program test, which would randomly give an `UnbalancedInstruction` error. See the commit messages from #465 for more info.

#### Solution

Avoid passing the same account twice, which doesn't work properly in 1.13, since there used to be a race when updating accounts. This is currently fixed in master, so I'll be adding a test to solana-program-test to make sure we don't introduce that regression again.