### PR TITLE
bot: Save classifications before distributing stake

### DIFF
--- a/bot/src/noop_stake_pool.rs
+++ b/bot/src/noop_stake_pool.rs
@@ -1,3 +1,4 @@
+use log::info;
 use solana_sdk::pubkey::Pubkey;
 use {
     crate::{generic_stake_pool::*, rpc_client_utils::MultiClient},
@@ -17,7 +18,7 @@ impl GenericStakePool for NoopStakePool {
     fn apply(
         &mut self,
         _client: &MultiClient,
-        _dry_run: bool,
+        dry_run: bool,
         desired_validator_stake: &[ValidatorStake],
     ) -> Result<
         (
@@ -38,7 +39,12 @@ impl GenericStakePool for NoopStakePool {
             })
             .collect();
 
-        let notes = vec!["This is the noop stake pool. All number are make-believe.".to_string()];
+        info!("NoopStakePool run with dry_run={}", dry_run);
+
+        let notes = vec![
+            "This is the noop stake pool. All number are make-believe, and stake never distributed"
+                .to_string(),
+        ];
 
         Ok((notes, validator_stake_actions, HashSet::new(), 12_345))
     }

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -18,6 +18,11 @@ else
   EPOCH_CLASSIFICATION="--epoch-classification first"
 fi
 
+# Re-classifies all validators, even if they have already been classified
+if [[ _n $IGNORE_EXISTING_CLASSIFICATION ]]; then
+  IGNORE_EXISTING_CLASSIFICATION = "--ignore-existing-classification"
+fi
+
 if [[ -n $NO_WIKI_OUTPUT ]]; then
   CSV_OUTPUT_MODE="--csv-output-mode no"
   EPOCH_CLASSIFICATION="--epoch-classification no"
@@ -139,6 +144,7 @@ SHARED_ARGS=(
   $PERFORMANCE_WAIVER_RELEASE_VERSION
   $MAX_POOR_VOTER_PERCENTAGE
   $MIN_EPOCH_CREDIT_PERCENTAGE_OF_AVERAGE
+  $IGNORE_EXISTING_CLASSIFICATION
 )
 
 if [[ $CLUSTER = "testnet-stake-pool" ]]; then

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -19,8 +19,8 @@ else
 fi
 
 # Re-classifies all validators, even if they have already been classified
-if [[ _n $IGNORE_EXISTING_CLASSIFICATION ]]; then
-  IGNORE_EXISTING_CLASSIFICATION = "--ignore-existing-classification"
+if [[ -n $IGNORE_EXISTING_CLASSIFICATION ]]; then
+  IGNORE_EXISTING_CLASSIFICATION="--ignore-existing-classification"
 fi
 
 if [[ -n $NO_WIKI_OUTPUT ]]; then


### PR DESCRIPTION
If --require-dry-run-to-distribute-stake is set, the first time the bot is run in an epoch it will classify validators and save those classifications to the yml file, but it will _not_ distribute stake. The next time the bot is run in the epoch, it will load the classifications from the yml file and distribute stake.

Also add --ignore-existing-classification flag that forces re-classification of validators. Useful for test dry runs when classification has already happened.