### PR TITLE
Bot: Change how RPC URLs are set

### DIFF
--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -972,11 +972,11 @@ mod test {
             .add_program("spl_stake_pool", spl_stake_pool::id());
         let (test_validator, authorized_staker) = test_validator_genesis.start();
 
-        let mut config = Config::default_for_test();
-        config.websocket_url = test_validator.rpc_pubsub_url();
+        let config = Config::default_for_test();
+        let websocket_url = test_validator.rpc_pubsub_url();
         let rpc_client = test_validator.get_rpc_client();
         let rpc_client = Arc::new(rpc_client);
-        let tpu_client = new_tpu_client_with_retry(&rpc_client, &config.websocket_url).unwrap();
+        let tpu_client = new_tpu_client_with_retry(&rpc_client, &websocket_url).unwrap();
         let client = MultiClient::new(rpc_client, tpu_client, &config);
 
         let stake_pool = Keypair::new();

--- a/bot/src/stake_pool_v0.rs
+++ b/bot/src/stake_pool_v0.rs
@@ -920,11 +920,11 @@ mod test {
         ));
         let (test_validator, authorized_staker) = test_validator_genesis.start();
 
-        let mut config = Config::default_for_test();
-        config.websocket_url = test_validator.rpc_pubsub_url();
+        let config = Config::default_for_test();
+        let websocket_url = test_validator.rpc_pubsub_url();
         let rpc_client = test_validator.get_rpc_client();
         let rpc_client = Arc::new(rpc_client);
-        let tpu_client = new_tpu_client_with_retry(&rpc_client, &config.websocket_url).unwrap();
+        let tpu_client = new_tpu_client_with_retry(&rpc_client, &websocket_url).unwrap();
         let client = MultiClient::new(rpc_client, tpu_client, &config);
 
         let authorized_staker_address = authorized_staker.pubkey();

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -7,7 +7,8 @@ set -ex
 DIR="$(dirname "$0")"
 
 # Convert space-delimited string into array
-IFS=" " read -r -a URL <<< "$URL"
+IFS=" " read -r -a MAINNET_BETA_JSON_RPC_URL <<< "$MAINNET_BETA_JSON_RPC_URL"
+IFS=" " read -r -a TESTNET_JSON_RPC_URL <<< "$TESTNET_JSON_RPC_URL"
 
 "$DIR"/fetch-release.sh "$STAKE_O_MATIC_RELEASE"
 
@@ -72,8 +73,6 @@ fi
 
 # shellcheck disable=SC2206
 TESTNET_ARGS=(
-  --url ${URL[@]:?}
-  --participant-url ${PARTICIPANT_URL:?}
   --cluster testnet
   --quality-block-producer-percentage 30
   --max-infrastructure-concentration 25
@@ -87,8 +86,6 @@ TESTNET_ARGS=(
 
 # shellcheck disable=SC2206
 MAINNET_BETA_ARGS=(
-  --url ${URL[@]:?}
-  --participant-url ${URL:?}
   --cluster mainnet-beta
   --quality-block-producer-percentage 30
   --max-active-stake 3000000
@@ -127,6 +124,8 @@ STAKE_POOL_ARGS=(
 
 # shellcheck disable=SC2206
 SHARED_ARGS=(
+  --mainnet-beta-json-rpc-url ${MAINNET_BETA_JSON_RPC_URL[@]:?}
+  --testnet-json-rpc-url ${TESTNET_JSON_RPC_URL[@]:?}
   $MAX_POOR_BLOCK_PRODUCER_PERCENTAGE
   $REQUIRE_DRY_RUN_TO_DISTRIBUTE_STAKE
   $BLOCKLIST


### PR DESCRIPTION
URLs are now set using the --mainnet-beta-json-rpc-url and --testnet-json-rpc-url flags.