### PR TITLE
Bot: Change how RPC URLs are set

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -7,6 +7,7 @@ use crate::slack_utils::send_slack_channel_message;
 use crate::stake_pool_v0::MIN_STAKE_ACCOUNT_BALANCE;
 use crate::validators_app::CommissionChangeIndexHistoryEntry;
 use crate::Cluster::{MainnetBeta, Testnet};
+use solana_client::tpu_client::TpuClient;
 use std::env;
 use {
     crate::{db::*, generic_stake_pool::*, rpc_client_utils::*},
@@ -165,9 +166,6 @@ impl std::fmt::Display for Cluster {
 
 #[derive(Debug, Serialize)]
 pub struct Config {
-    json_rpc_url: String,
-    websocket_url: String,
-    participant_json_rpc_url: String,
     cluster: Cluster,
     db_path: PathBuf,
     db_suffix: String,
@@ -279,12 +277,7 @@ impl Config {
     #[cfg(test)]
     pub fn default_for_test() -> Self {
         Self {
-            json_rpc_url: DEFAULT_MAINNET_BETA_JSON_RPC_URL.to_string(),
-            websocket_url: solana_cli_config::Config::compute_websocket_url(
-                DEFAULT_MAINNET_BETA_JSON_RPC_URL,
-            ),
-            participant_json_rpc_url: DEFAULT_MAINNET_BETA_JSON_RPC_URL.to_string(),
-            cluster: Cluster::MainnetBeta,
+            cluster: MainnetBeta,
             db_path: PathBuf::default(),
             db_suffix: "".to_string(),
             csv_output_mode: OutputMode::No,
@@ -352,7 +345,14 @@ fn app_version() -> String {
     })
 }
 
-fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
+struct GetConfigResult {
+    config: Config,
+    mainnet_beta_multi_client: MultiClient,
+    testnet_multi_client: MultiClient,
+    stake_pool: Box<dyn GenericStakePool>,
+}
+
+fn get_config() -> BoxResult<GetConfigResult> {
     let default_confirmed_block_cache_path = default_confirmed_block_cache_path()
         .to_str()
         .unwrap()
@@ -366,22 +366,22 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::InferSubcommands)
         .arg(
-            Arg::with_name("json_rpc_url")
-                .long("url")
+            Arg::with_name("mainnet_beta_json_rpc_url")
+                .long("mainnet-beta-json-rpc-url")
                 .value_name("URL")
                 .takes_value(true)
                 .multiple(true)
                 .validator(is_url)
-                .help("JSON RPC URLs for the cluster. Bot will use first URL that works")
+                .help("Mainnet Beta JSON RPC URLs for the cluster. Bot will use first URL that works")
         )
         .arg(
-            Arg::with_name("participant_json_rpc_url")
-                .long("participant-url")
+            Arg::with_name("testnet_json_rpc_url")
+                .long("testnet-json-rpc-url")
                 .value_name("URL")
                 .takes_value(true)
+                .multiple(true)
                 .validator(is_url)
-                .default_value(DEFAULT_MAINNET_BETA_JSON_RPC_URL)
-                .help("JSON RPC URL for the participant cluster, typically a mainnet URL")
+                .help("Testnet JSON RPC URLs for the cluster. Bot will use first URL that works")
         )
         .arg(
             Arg::with_name("cluster")
@@ -881,62 +881,9 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
     let require_dry_run_to_distribute_stake =
         matches.is_present("require_dry_run_to_distribute_stake");
 
-    let default_json_rpc_url = match cluster {
-        Cluster::MainnetBeta => DEFAULT_MAINNET_BETA_JSON_RPC_URL,
-        Cluster::Testnet => DEFAULT_TESTNET_JSON_RPC_URL,
-    }
-    .to_string();
-
-    // Create a list of RPC URLs to try. The first URL that returns a successful "getHealth" response
-    // will be used for all requests
-    let json_rpc_urls_to_try: Vec<String> = match values_t!(matches, "json_rpc_url", String) {
-        Ok(argument_urls) => {
-            let mut urls = argument_urls;
-            urls.push(default_json_rpc_url);
-
-            urls
-        }
-        _ => {
-            vec![default_json_rpc_url]
-        }
-    };
-
-    let (rpc_client, json_rpc_url) = json_rpc_urls_to_try
-        .iter()
-        .map(|url| {
-            let rpc_client = Arc::new(RpcClient::new_with_timeout_and_commitment(
-                url.clone(),
-                Duration::from_secs(180),
-                CommitmentConfig::finalized(),
-            ));
-            (rpc_client, url.clone())
-        })
-        .find(|(rpc_client, url)| {
-            info!("Checking health of {}", url);
-            matches!(check_rpc_health(rpc_client), Ok(_))
-        })
-        .unwrap_or_else(|| {
-            error!("All RPC servers are unhealthy. Exiting.");
-            process::exit(1);
-        });
-
-    info!("using RPC URL: {}", json_rpc_url);
-
-    let websocket_url = solana_cli_config::Config::compute_websocket_url(&json_rpc_url);
-    let tpu_client = new_tpu_client_with_retry(&rpc_client, &websocket_url).unwrap_or_else(|e| {
-        error!("Unable to connect to TPU at {websocket_url}: {e:?}");
-        process::exit(1);
-    });
-    let participant_json_rpc_url = matches
-        .value_of("participant_json_rpc_url")
-        .unwrap()
-        .to_string();
     let use_rpc_tx_submission = matches.is_present("use_rpc_tx_submission");
 
     let mut config = Config {
-        json_rpc_url,
-        websocket_url,
-        participant_json_rpc_url,
         cluster,
         db_path,
         db_suffix,
@@ -973,10 +920,30 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
         use_rpc_tx_submission,
     };
 
+    let mut mainnet_urls_to_try =
+        values_t!(matches, "mainnet_beta_json_rpc_url", String).unwrap_or_default();
+    mainnet_urls_to_try.push(DEFAULT_MAINNET_BETA_JSON_RPC_URL.parse().unwrap());
+    let (mainnet_beta_rpc_client, mainnet_beta_tpu_client) =
+        try_json_rpc_urls(mainnet_urls_to_try)?;
+    let mainnet_beta_multi_client =
+        MultiClient::new(mainnet_beta_rpc_client, mainnet_beta_tpu_client, &config);
+
     info!(
-        "config.max_poor_voter_percentage: {}",
-        config.max_poor_voter_percentage
+        "Using Mainnet Beta RPC URL {}",
+        mainnet_beta_multi_client.url()
     );
+
+    let mut testnet_urls_to_try =
+        values_t!(matches, "testnet_json_rpc_url", String).unwrap_or_default();
+    testnet_urls_to_try.push(DEFAULT_TESTNET_JSON_RPC_URL.parse().unwrap());
+    let (testnet_rpc_client, testnet_tpu_client) = try_json_rpc_urls(testnet_urls_to_try)?;
+    let testnet_multi_client = MultiClient::new(testnet_rpc_client, testnet_tpu_client, &config);
+    info!("Using Testnet RPC URL {}", testnet_multi_client.url());
+
+    let cluster_multi_client = match cluster {
+        Testnet => &testnet_multi_client,
+        MainnetBeta => &mainnet_beta_multi_client,
+    };
 
     let stake_pool: Box<dyn GenericStakePool> = match matches.subcommand() {
         ("stake-pool-v0", Some(matches)) => {
@@ -995,7 +962,7 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
             config.baseline_stake_amount_lamports = Some(baseline_stake_amount);
 
             Box::new(stake_pool_v0::new(
-                &rpc_client,
+                cluster_multi_client,
                 authorized_staker,
                 baseline_stake_amount,
                 reserve_stake_address,
@@ -1018,7 +985,7 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
             config.baseline_stake_amount_lamports = Some(baseline_stake_amount);
 
             Box::new(stake_pool::new(
-                &rpc_client,
+                cluster_multi_client,
                 authorized_staker,
                 pool_address,
                 baseline_stake_amount,
@@ -1029,8 +996,42 @@ fn get_config() -> BoxResult<(Config, MultiClient, Box<dyn GenericStakePool>)> {
         _ => unreachable!(),
     };
 
-    let client = MultiClient::new(rpc_client, tpu_client, &config);
-    Ok((config, client, stake_pool))
+    Ok(GetConfigResult {
+        config,
+        mainnet_beta_multi_client,
+        testnet_multi_client,
+        stake_pool,
+    })
+}
+
+/// Takes a list of JSON RPC Urls, and returns an RpcClient and TpuClient for the first server that is health
+fn try_json_rpc_urls(urls_to_try: Vec<String>) -> BoxResult<(Arc<RpcClient>, TpuClient)> {
+    let (rpc_client, json_rpc_url) = urls_to_try
+        .iter()
+        .map(|url| {
+            let rpc_client = Arc::new(RpcClient::new_with_timeout_and_commitment(
+                url.clone(),
+                Duration::from_secs(180),
+                CommitmentConfig::confirmed(),
+            ));
+            (rpc_client, url.clone())
+        })
+        .find(|(rpc_client, url)| {
+            info!("Checking health of {}", url);
+            matches!(check_rpc_health(rpc_client), Ok(_))
+        })
+        .unwrap_or_else(|| {
+            error!("All RPC servers are unhealthy. Exiting.");
+            process::exit(1);
+        });
+
+    let websocket_url = solana_cli_config::Config::compute_websocket_url(&json_rpc_url);
+    let tpu_client = new_tpu_client_with_retry(&rpc_client, &websocket_url).unwrap_or_else(|e| {
+        error!("Unable to connect to TPU at {websocket_url}: {e:?}");
+        process::exit(1);
+    });
+
+    Ok((rpc_client, tpu_client))
 }
 
 type ClassifyResult = (
@@ -1345,8 +1346,10 @@ fn get_testnet_participation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn classify(
     rpc_client: &RpcClient,
+    testnet_rpc_client: &RpcClient,
     config: &Config,
     epoch: Epoch,
     validator_list: &ValidatorList,
@@ -1356,10 +1359,6 @@ fn classify(
 ) -> BoxResult<EpochClassificationV1> {
     let last_epoch = epoch - 1;
 
-    let testnet_rpc_client = RpcClient::new_with_timeout(
-        DEFAULT_TESTNET_JSON_RPC_URL.to_string(), // TODO: should be configurable
-        Duration::from_secs(180),
-    );
     let testnet_epoch = testnet_rpc_client.get_epoch_info()?.epoch;
     info!(
         "Using testnet epoch {:?} as most recent epoch for testnet metrics",
@@ -2309,13 +2308,15 @@ fn warn_validator_for_infrastructure_concentration(
 fn main() -> BoxResult<()> {
     solana_logger::setup_with_default("solana=info");
 
-    let (config, client, mut stake_pool) = get_config()?;
+    let GetConfigResult {
+        config,
+        mainnet_beta_multi_client,
+        testnet_multi_client,
+        mut stake_pool,
+    } = get_config()?;
 
     info!("Loading participants...");
-    let all_participants = get_participants_with_state(
-        &RpcClient::new(config.participant_json_rpc_url.clone()),
-        None,
-    )?;
+    let all_participants = get_participants_with_state(&mainnet_beta_multi_client, None)?;
 
     let (approved_participants, non_rejected_participants) = all_participants.iter().fold(
         (HashMap::new(), HashMap::new()),
@@ -2367,7 +2368,12 @@ fn main() -> BoxResult<()> {
         Notifier::default()
     };
 
-    let epoch = client.get_epoch_info()?.epoch;
+    let cluster_multi_client = match config.cluster {
+        Testnet => &testnet_multi_client,
+        MainnetBeta => &mainnet_beta_multi_client,
+    };
+
+    let epoch = cluster_multi_client.get_epoch_info()?.epoch;
     info!("Current epoch: {:?}", epoch);
     if epoch == 0 {
         return Ok(());
@@ -2430,7 +2436,8 @@ fn main() -> BoxResult<()> {
 
         (
             classify(
-                &client,
+                cluster_multi_client,
+                &testnet_multi_client,
                 &config,
                 epoch,
                 &validator_list,
@@ -2540,7 +2547,11 @@ fn main() -> BoxResult<()> {
         );
 
         let (stake_pool_notes, validator_stake_actions, unfunded_validators, bonus_stake_amount) =
-            stake_pool.apply(&client, !distribute_stake, &desired_validator_stake)?;
+            stake_pool.apply(
+                cluster_multi_client,
+                pre_run_dry_run || config.dry_run,
+                &desired_validator_stake,
+            )?;
 
         let mut summary_messages: Vec<String> = vec![format!(
             "summary for {:?}/{:?}\n",

--- a/bot/src/stake_pool.rs
+++ b/bot/src/stake_pool.rs
@@ -975,11 +975,11 @@ mod test {
             .add_program("spl_stake_pool", spl_stake_pool::id());
         let (test_validator, authorized_staker) = test_validator_genesis.start();
 
-        let mut config = Config::default_for_test();
-        config.websocket_url = test_validator.rpc_pubsub_url();
+        let config = Config::default_for_test();
+        let websocket_url = test_validator.rpc_pubsub_url();
         let rpc_client = test_validator.get_rpc_client();
         let rpc_client = Arc::new(rpc_client);
-        let tpu_client = new_tpu_client_with_retry(&rpc_client, &config.websocket_url).unwrap();
+        let tpu_client = new_tpu_client_with_retry(&rpc_client, &websocket_url).unwrap();
         let client = MultiClient::new(rpc_client, tpu_client, &config);
 
         let stake_pool = Keypair::new();

--- a/bot/src/stake_pool_v0.rs
+++ b/bot/src/stake_pool_v0.rs
@@ -919,11 +919,11 @@ mod test {
         ));
         let (test_validator, authorized_staker) = test_validator_genesis.start();
 
-        let mut config = Config::default_for_test();
-        config.websocket_url = test_validator.rpc_pubsub_url();
+        let config = Config::default_for_test();
+        let websocket_url = test_validator.rpc_pubsub_url();
         let rpc_client = test_validator.get_rpc_client();
         let rpc_client = Arc::new(rpc_client);
-        let tpu_client = new_tpu_client_with_retry(&rpc_client, &config.websocket_url).unwrap();
+        let tpu_client = new_tpu_client_with_retry(&rpc_client, &websocket_url).unwrap();
         let client = MultiClient::new(rpc_client, tpu_client, &config);
 
         let authorized_staker_address = authorized_staker.pubkey();

--- a/stake-o-matic.sh
+++ b/stake-o-matic.sh
@@ -7,7 +7,8 @@ set -ex
 DIR="$(dirname "$0")"
 
 # Convert space-delimited string into array
-IFS=" " read -r -a URL <<< "$URL"
+IFS=" " read -r -a MAINNET_BETA_JSON_RPC_URL <<< "$MAINNET_BETA_JSON_RPC_URL"
+IFS=" " read -r -a TESTNET_JSON_RPC_URL <<< "$TESTNET_JSON_RPC_URL"
 
 "$DIR"/fetch-release.sh "$STAKE_O_MATIC_RELEASE"
 
@@ -77,8 +78,6 @@ fi
 
 # shellcheck disable=SC2206
 TESTNET_ARGS=(
-  --url ${URL[@]:?}
-  --participant-url ${PARTICIPANT_URL:?}
   --cluster testnet
   --quality-block-producer-percentage 30
   --max-infrastructure-concentration 25
@@ -92,8 +91,6 @@ TESTNET_ARGS=(
 
 # shellcheck disable=SC2206
 MAINNET_BETA_ARGS=(
-  --url ${URL[@]:?}
-  --participant-url ${URL:?}
   --cluster mainnet-beta
   --quality-block-producer-percentage 30
   --max-active-stake 3000000
@@ -132,6 +129,8 @@ STAKE_POOL_ARGS=(
 
 # shellcheck disable=SC2206
 SHARED_ARGS=(
+  --mainnet-beta-json-rpc-url ${MAINNET_BETA_JSON_RPC_URL[@]:?}
+  --testnet-json-rpc-url ${TESTNET_JSON_RPC_URL[@]:?}
   $MAX_POOR_BLOCK_PRODUCER_PERCENTAGE
   $REQUIRE_DRY_RUN_TO_DISTRIBUTE_STAKE
   $BLOCKLIST


### PR DESCRIPTION
URLs are now set using the --mainnet-beta-json-rpc-url and --testnet-json-rpc-url flags.