### PR TITLE
bot: Respect the inactive balance when destaking

### DIFF
--- a/bot/src/rpc_client_utils.rs
+++ b/bot/src/rpc_client_utils.rs
@@ -285,23 +285,24 @@ pub fn send_and_confirm_transactions_with_spinner(
     Err("Max retries exceeded".into())
 }
 
-pub(crate) fn get_stake_with_fallback(
+pub(crate) fn get_active_and_inactive_stake(
     rpc_client: &RpcClient,
     stake_address: &Pubkey,
 ) -> Result<(u64, u64), Box<dyn error::Error>> {
     let stake_activation = rpc_client.get_stake_activation(*stake_address, None);
+    let stake_balance = rpc_client.get_balance(stake_address).map_err(|err| {
+        format!(
+            "Unable to get stake account balance: {}: {}",
+            stake_address, err
+        )
+    })?;
     if let Ok(stake_activation) = stake_activation {
-        Ok((stake_activation.active, stake_activation.inactive))
-    } else {
         Ok((
-            0,
-            rpc_client.get_balance(stake_address).map_err(|err| {
-                format!(
-                    "Unable to get stake account balance: {}: {}",
-                    stake_address, err
-                )
-            })?,
+            stake_activation.active,
+            stake_balance - stake_activation.active,
         ))
+    } else {
+        Ok((0, stake_balance))
     }
 }
 


### PR DESCRIPTION
#### Problem

When destaking a validator, the "desired balance" at the end is hardcoded to the minimum stake delegation + rent exemption. This isn't correct unfortunately! When two active stakes merge, the absorbed stake account's rent gets added as inactive lamports to the destination stake. In order to meet the minimum stake delegation requirement, the destination stake must then leave `minimum_stake_delegation + 2 * rent_exemption`!

#### Solution

There are many cases to cover, so let's keep this simple and separate the active / inactive amounts, and be sure to leave minimum stake delegation + inactive amount when destaking a validator.